### PR TITLE
fix: remove Mac support from CI/CD pipeline

### DIFF
--- a/.github/actions/install-system-deps/action.yml
+++ b/.github/actions/install-system-deps/action.yml
@@ -2,7 +2,7 @@ name: 'Install System Dependencies'
 description: 'Install system dependencies for Tauri builds across platforms'
 inputs:
   os:
-    description: 'Operating system (ubuntu, macos, windows)'
+    description: 'Operating system (ubuntu, windows)'
     required: true
 runs:
   using: 'composite'
@@ -151,14 +151,6 @@ runs:
         find /usr/lib -name "*webkit*.pc" -o -name "*javascript*.pc" 2>/dev/null | head -10 || echo "None found"
         
         echo "🎉 Ubuntu system dependencies installation completed!"
-
-    - name: Install system dependencies (macOS)
-      if: inputs.os == 'macos'
-      shell: bash
-      run: |
-        echo "🔧 Installing system dependencies for macOS..."
-        # macOS typically doesn't need additional system dependencies for Tauri
-        echo "✅ macOS dependencies check completed!"
 
     - name: Install system dependencies (Windows)
       if: inputs.os == 'windows'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -213,12 +213,6 @@ jobs:
           - platform: 'windows-latest'
             args: '--target x86_64-pc-windows-msvc'
             target: 'x86_64-pc-windows-msvc'
-          - platform: 'macos-latest'
-            args: '--target aarch64-apple-darwin'
-            target: 'aarch64-apple-darwin'
-          - platform: 'macos-latest'
-            args: '--target x86_64-apple-darwin'
-            target: 'x86_64-apple-darwin'
           - platform: 'ubuntu-22.04'
             args: '--target x86_64-unknown-linux-gnu'
             target: 'x86_64-unknown-linux-gnu'
@@ -260,7 +254,7 @@ jobs:
       - name: Install system dependencies
         uses: ./.github/actions/install-system-deps
         with:
-          os: ${{ matrix.platform == 'ubuntu-22.04' && 'ubuntu' || (contains(matrix.platform, 'macos') && 'macos' || 'windows') }}
+          os: ${{ matrix.platform == 'ubuntu-22.04' && 'ubuntu' || 'windows' }}
 
       - name: Install frontend dependencies
         shell: bash
@@ -347,7 +341,6 @@ jobs:
             
             #### Installation
             - **Windows**: Download the `.msi` installer for a guided installation, or the `.exe` for a portable experience
-            - **macOS**: Download the `.dmg` file for Apple Silicon (M1/M2) or Intel processors
             - **Linux**: Download the `.AppImage` for a portable experience or the `.deb` for Debian/Ubuntu systems
             
             #### Features
@@ -359,7 +352,6 @@ jobs:
             
             #### System Requirements
             - **Windows**: Windows 10 or later
-            - **macOS**: macOS 10.15 or later
             - **Linux**: Any modern distribution with GTK 3.24+
             
             ---
@@ -375,7 +367,7 @@ jobs:
           echo "🔍 Verifying build artifacts and generating checksums..."
           
           # Find all release files in common Tauri output locations
-          RELEASE_FILES=$(find . -type f \( -name "*.msi" -o -name "*.exe" -o -name "*.dmg" -o -name "*.deb" -o -name "*.AppImage" -o -name "*.app.tar.gz" \) 2>/dev/null || true)
+          RELEASE_FILES=$(find . -type f \( -name "*.msi" -o -name "*.exe" -o -name "*.deb" -o -name "*.AppImage" \) 2>/dev/null || true)
           
           # Also check specific Tauri bundle locations
           if [ -z "$RELEASE_FILES" ]; then
@@ -384,14 +376,12 @@ jobs:
               "src-tauri/target/release/bundle"
               "src-tauri/target/x86_64-unknown-linux-gnu/release/bundle"
               "src-tauri/target/x86_64-pc-windows-msvc/release/bundle"
-              "src-tauri/target/aarch64-apple-darwin/release/bundle"
-              "src-tauri/target/x86_64-apple-darwin/release/bundle"
             )
             
             for location in "${BUNDLE_LOCATIONS[@]}"; do
               if [ -d "$location" ]; then
                 echo "📁 Checking: $location"
-                FOUND_FILES=$(find "$location" -type f \( -name "*.msi" -o -name "*.exe" -o -name "*.dmg" -o -name "*.deb" -o -name "*.AppImage" \) 2>/dev/null || true)
+                FOUND_FILES=$(find "$location" -type f \( -name "*.msi" -o -name "*.exe" -o -name "*.deb" -o -name "*.AppImage" \) 2>/dev/null || true)
                 if [ -n "$FOUND_FILES" ]; then
                   RELEASE_FILES="$RELEASE_FILES $FOUND_FILES"
                 fi
@@ -451,14 +441,6 @@ jobs:
                     osslsigncode verify "$file" && echo "  ✅ Windows signature verified" || echo "  ⚠️ Windows signature check failed"
                   else
                     echo "  ℹ️ Windows signature verification skipped (osslsigncode not available)"
-                  fi
-                  ;;
-                *.dmg)
-                  # macOS: Check code signature
-                  if [[ "$RUNNER_OS" == "macOS" ]]; then
-                    codesign -dv --verbose=4 "$file" 2>&1 && echo "  ✅ macOS signature verified" || echo "  ⚠️ macOS signature check failed"
-                  else
-                    echo "  ℹ️ macOS signature verification skipped (not on macOS)"
                   fi
                   ;;
                 *.deb|*.AppImage)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Version](https://img.shields.io/github/v/release/fynn9563/vrchat-photo-uploader)
 ![License](https://img.shields.io/github/license/fynn9563/vrchat-photo-uploader?branch=master)
-![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-brightgreen)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux-brightgreen)
 
 A powerful desktop application for uploading VRChat photos to Discord with intelligent grouping, automatic metadata extraction, and seamless integration.
  
@@ -24,7 +24,6 @@ A powerful desktop application for uploading VRChat photos to Discord with intel
 1. **Download** the latest release for your platform from the [Releases page](https://github.com/fynn9563/vrchat-photo-uploader/releases)
 2. **Install** the application:
    - **Windows**: Run the `.msi` installer or use the portable `.exe`
-   - **macOS**: Open the `.dmg` file and drag to Applications
    - **Linux**: Use the `.AppImage` (portable) or install the `.deb` package
 3. **Configure** your Discord webhook in the app
 4. **Select** your VRChat photos and upload!
@@ -34,10 +33,6 @@ A powerful desktop application for uploading VRChat photos to Discord with intel
 ### Windows
 - **Installer**: Download `VRChat-Photo-Uploader-v{version}-x64.msi` for guided installation
 - **Portable**: Download `VRChat-Photo-Uploader-v{version}-x64.exe` for standalone use
-
-### macOS
-- **Apple Silicon (M1/M2)**: Download `VRChat-Photo-Uploader-v{version}-aarch64.dmg`
-- **Intel**: Download `VRChat-Photo-Uploader-v{version}-x64.dmg`
 
 ### Linux
 - **AppImage (Portable)**: Download `VRChat-Photo-Uploader-v{version}-x86_64.AppImage`
@@ -86,7 +81,6 @@ A powerful desktop application for uploading VRChat photos to Discord with intel
 ## ⚙️ System Requirements
 
 - **Windows**: Windows 10 or later
-- **macOS**: macOS 10.15 (Catalina) or later
 - **Linux**: Any modern distribution with GTK 3.24+
 
 ## 🤝 Contributing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ $hash.Hash
 Get-Content SHA256SUMS | Select-String "VRChat-Photo-Uploader.msi"
 ```
 
-#### macOS/Linux
+#### Linux
 ```bash
 # Verify checksum
 sha256sum -c SHA256SUMS --ignore-missing
@@ -33,13 +33,6 @@ sha256sum -c SHA256SUMS --ignore-missing
 ```powershell
 # Check Authenticode signature
 Get-AuthenticodeSignature .\VRChat-Photo-Uploader.msi
-```
-
-**macOS (.dmg files)**:
-```bash
-# Verify code signature
-codesign -dv --verbose=4 VRChat-Photo-Uploader.dmg
-spctl -a -t open --context context:primary-signature -v VRChat-Photo-Uploader.dmg
 ```
 
 **Linux (.deb, .AppImage files)**:
@@ -56,7 +49,7 @@ All releases are built using GitHub Actions with the following security measures
 - **Dependency auditing**: All dependencies are scanned for known vulnerabilities
 - **Signature verification**: Build artifacts are verified during CI/CD
 - **Checksum generation**: SHA256 checksums are generated for all releases
-- **Multi-platform builds**: Consistent builds across Windows, macOS, and Linux
+- **Multi-platform builds**: Consistent builds across Windows and Linux
 
 ## 🚨 Security Issues
 
@@ -84,7 +77,6 @@ Each release includes:
 | Platform | File Types | Signing Method |
 |----------|------------|----------------|
 | Windows | `.exe`, `.msi` | Authenticode (if configured) |
-| macOS | `.dmg` | Apple Developer ID |
 | Linux | `.deb`, `.AppImage` | Checksum verification |
 
 ## 🔒 Security Features


### PR DESCRIPTION
- Remove both aarch64-apple-darwin and x86_64-apple-darwin build targets
- Clean up Mac-specific bundle locations and verification code
- Update release notes to reflect Windows/Linux only support
- Remove macOS references from README.md and SECURITY.md
- Simplify system dependency detection logic
- Remove macOS dependency installation from GitHub Actions