### PR TITLE
Release v4.1.1: multi-webhook upload, player tagging, security fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Discord webhook URLs used by CI integration tests.
+# These are NOT required to run or build the app — only needed to run the
+# real Discord upload integration tests in the test suite.
+# Set them as GitHub Secrets (DISCORD_WEBHOOK_URL, DISCORD_FORUM_WEBHOOK_URL)
+# for CI, or populate locally if you want to run the integration tests yourself.
+
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your_id/your_token
+DISCORD_FORUM_WEBHOOK_URL=https://discord.com/api/webhooks/your_id/your_token

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,13 @@ tauri_*
 # Environment variables
 .env
 .env.*
+!.env.example
+
+# Dev notes (local only, not for VCS)
+.dev/
+
+# Windows junk
+Thumbs.db
+
+# Stray shell artifacts
+~/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [4.1.1] - 2026-04-26
+
+### Fixed
+- Embed Metadata no longer fails with "Invalid file path detected" for valid PNG files whose filename contains two consecutive dots, or whose path contains a tilde (such as Windows short folder names like `PROGRA~1`)
+
+### Security
+- Updated networking and archive-handling dependencies to patch known vulnerabilities
+
 ## [4.1.0] - 2026-02-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vrcx-image-to-discord",
   "private": true,
-  "version": "4.1.0",
+  "version": "4.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "VRChat-Photo-Uploader"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -139,7 +139,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1078,7 +1078,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1307,7 +1307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3652,7 +3652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4687,7 +4687,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4752,7 +4752,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4763,9 +4763,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5752,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -6168,7 +6168,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7123,7 +7123,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "VRChat-Photo-Uploader"
-version = "4.1.0"
+version = "4.1.1"
 description = "A powerful tool for uploading VRChat photos to Discord"
 authors = ["Fynn9563"]
 repository = "https://github.com/fynn9563/vrchat-photo-uploader"

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -1,6 +1,6 @@
 use crate::errors::{AppError, AppResult};
 use regex::Regex;
-use std::path::Path;
+use std::path::{Component, Path};
 
 pub struct InputValidator;
 
@@ -67,8 +67,13 @@ impl InputValidator {
 
         let path_obj = Path::new(path);
 
-        // Check for path traversal attempts
-        if path.contains("..") || path.contains("~") {
+        let has_parent_dir = path_obj
+            .components()
+            .any(|c| matches!(c, Component::ParentDir));
+        let starts_with_tilde =
+            path.starts_with('~') || path.starts_with("~/") || path.starts_with("~\\");
+
+        if has_parent_dir || starts_with_tilde {
             return Err(AppError::validation(
                 "file_path",
                 "Invalid file path detected",
@@ -326,7 +331,10 @@ mod tests {
         let invalid_paths = vec![
             ("", "empty path"),
             ("../etc/passwd", "path traversal"),
+            ("..\\windows\\system32\\file.png", "windows path traversal"),
+            ("foo/../../etc/passwd", "embedded path traversal"),
             ("~/secret/file.png", "home directory traversal"),
+            ("~\\secret\\file.png", "windows home directory traversal"),
             ("file.txt", "not an image extension"),
             ("file.exe", "executable file"),
             ("image", "no extension"),
@@ -336,6 +344,27 @@ mod tests {
             assert!(
                 InputValidator::validate_file_path(path).is_err(),
                 "Invalid path '{path}' should fail validation ({reason})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_file_path_allows_dots_and_tildes_in_names() {
+        let temp_dir = std::env::temp_dir();
+        let cases = vec!["screenshot..png", "PROGRA~1.png", "photo..backup.png"];
+
+        for name in cases {
+            let path = temp_dir.join(name);
+            File::create(&path).expect("create temp file");
+
+            let result = InputValidator::validate_file_path(&path.to_string_lossy());
+            let _ = std::fs::remove_file(&path);
+
+            assert!(
+                result.is_ok(),
+                "Path '{}' should pass validation but got: {:?}",
+                path.display(),
+                result.err()
             );
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
   },
   "productName": "VRChat Photo Uploader",
   "mainBinaryName": "VRChat-Photo-Uploader",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "identifier": "com.vrchat.photo.uploader",
   "plugins": {
     "updater": {


### PR DESCRIPTION
## Summary
- **v4.1.0 features**: multi-webhook upload, Discord player @mention tagging, webhook pinning, per-webhook forum channel setting, multi-webhook auto-upload, redesigned webhook selector
- **Security hardening**: XSS protection, path traversal guards, CSP enabled
- **v4.1.1 fix**: path validation no longer rejects valid PNGs whose filename contains two consecutive dots, or whose path contains a tilde (e.g. Windows 8.3 short names like `PROGRA~1`). Previously these triggered a false "Invalid file path detected" error in Embed Metadata.
- **Dependency CVEs patched**: `rustls-webpki` 0.103.9 -> 0.103.13 (4 CVEs) and `tar` 0.4.44 -> 0.4.45 (2 CVEs)

## Test plan
- [ ] CI passes (fmt, clippy, unit, integration, frontend, tsc)
- [ ] Embed Metadata into a PNG whose filename contains `..` succeeds (regression for v4.1.1)
- [ ] Embed Metadata into a PNG whose path contains a tilde succeeds
- [ ] Multi-webhook upload sends to all selected webhooks with correct progress display
- [ ] Discord @mentions resolve when player to Discord ID mappings exist
- [ ] Pinned webhooks appear at top of dropdowns and persist across restart
- [ ] Forum channel setting is configurable per webhook
- [ ] Auto-upload works in multi-webhook mode
- [ ] `cargo audit` shows only the unfixable `rsa` Marvin Attack advisory (transitive via unused sqlx mysql/postgres code paths)